### PR TITLE
feat: Integrate manager for auto-run and alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ UDP server installation for ZIVPN Tunnel (SSH/DNS/UDP) VPN app.
 
 #### Installation AMD
 ```
-wget -O zi.sh https://raw.githubusercontent.com/zahidbd2/udp-zivpn/main/zi.sh; sudo chmod +x zi.sh; sudo ./zi.sh
+wget -O install.sh https://raw.githubusercontent.com/kedaivpn/udp-zivpn/main/install.sh; sudo chmod +x install.sh; sudo ./install.sh
 ```
 
 #### Installation ARM
 ```
-bash <(curl -fsSL https://raw.githubusercontent.com/zahidbd2/udp-zivpn/main/zi2.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/kedaivpn/udp-zivpn/main/zi2.sh)
 ```
 
 
 ### Uninstall
 
 ```
-sudo wget -O ziun.sh https://raw.githubusercontent.com/zahidbd2/udp-zivpn/main/uninstall.sh; sudo chmod +x ziun.sh; sudo ./ziun.sh
+sudo wget -O ziun.sh https://raw.githubusercontent.com/kedaivpn/udp-zivpn/main/uninstall.sh; sudo chmod +x ziun.sh; sudo ./ziun.sh
 ```
 
 Client App available:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+# Zivpn UDP Module Manager
+# This script installs the base Zivpn service and then sets up an advanced management interface.
+
+# --- Pre-flight Checks ---
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script must be run as root. Please use sudo or run as root user." >&2
+  exit 1
+fi
+
+# --- Utility Functions ---
+function restart_zivpn() {
+    echo "Restarting ZIVPN service..."
+    systemctl restart zivpn.service
+    echo "Service restarted."
+}
+
+# --- Core Logic Functions ---
+function create_account() {
+    echo "--- Create New Account ---"
+    read -p "Enter new password: " password
+    if [ -z "$password" ]; then
+        echo "Password cannot be empty."
+        return
+    fi
+
+    read -p "Enter active period (in days): " days
+    if ! [[ "$days" =~ ^[0-9]+$ ]]; then
+        echo "Invalid number of days."
+        return
+    fi
+
+    local db_file="/etc/zivpn/users.db"
+    if grep -q "^${password}:" "$db_file"; then
+        echo "Password '${password}' already exists."
+        return
+    fi
+
+    local expiry_date=$(date -d "+$days days" +%s)
+    echo "${password}:${expiry_date}" >> "$db_file"
+    echo "User '${password}' added, expires in $days day(s)."
+
+    jq --arg pass "$password" '.auth.config += [$pass]' /etc/zivpn/config.json > /etc/zivpn/config.json.tmp && mv /etc/zivpn/config.json.tmp /etc/zivpn/config.json
+    echo "Configuration updated."
+    restart_zivpn
+}
+
+function delete_account() {
+    echo "--- Delete Account ---"
+    read -p "Enter password to delete: " password
+    if [ -z "$password" ]; then
+        echo "Password cannot be empty."
+        return
+    fi
+
+    local db_file="/etc/zivpn/users.db"
+    if [ ! -f "$db_file" ]; then
+        echo "User database not found."
+        return
+    fi
+
+    if ! grep -q "^${password}:" "$db_file"; then
+        echo "Password '${password}' not found."
+        return
+    fi
+
+    sed -i "/^${password}:/d" "$db_file"
+    echo "User '${password}' removed from database."
+
+    jq --arg pass "$password" 'del(.auth.config[] | select(. == $pass))' /etc/zivpn/config.json > /etc/zivpn/config.json.tmp && mv /etc/zivpn/config.json.tmp /etc/zivpn/config.json
+    echo "Configuration updated."
+    restart_zivpn
+}
+
+function change_domain() {
+    echo "--- Change Domain ---"
+    read -p "Enter the new domain name for the SSL certificate: " domain
+    if [ -z "$domain" ]; then
+        echo "Domain name cannot be empty."
+        return
+    fi
+
+    echo "Generating new certificate for domain '${domain}'..."
+    openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
+        -subj "/C=US/ST=California/L=Los Angeles/O=Example Corp/OU=IT Department/CN=${domain}" \
+        -keyout "/etc/zivpn/zivpn.key" -out "/etc/zivpn/zivpn.crt"
+
+    echo "New certificate generated."
+    restart_zivpn
+}
+
+function list_accounts() {
+    echo "--- Active Accounts ---"
+    local db_file="/etc/zivpn/users.db"
+
+    if [ ! -f "$db_file" ] || [ ! -s "$db_file" ]; then
+        echo "No accounts found."
+        return
+    fi
+
+    local current_date=$(date +%s)
+    printf "%-20s | %s\n" "Password" "Expires in (days)"
+    echo "------------------------------------------"
+    while IFS=':' read -r password expiry_date; do
+        if [[ -n "$password" ]]; then
+            local remaining_seconds=$((expiry_date - current_date))
+            if [ $remaining_seconds -gt 0 ]; then
+                local remaining_days=$((remaining_seconds / 86400))
+                printf "%-20s | %s days\n" "$password" "$remaining_days"
+            else
+                printf "%-20s | Expired\n" "$password"
+            fi
+        fi
+    done < "$db_file"
+    echo "------------------------------------------"
+}
+
+function show_menu() {
+    clear
+    echo "ZIVPN Account Manager"
+    echo "---------------------"
+    echo "1. Create Account"
+    echo "2. Delete Account"
+    echo "3. Change Domain"
+    echo "4. List Accounts"
+    echo "5. Exit"
+    echo "---------------------"
+    read -p "Enter your choice [1-5]: " choice
+
+    case $choice in
+        1) create_account ;;
+        2) delete_account ;;
+        3) change_domain ;;
+        4) list_accounts ;;
+        5) exit 0 ;;
+        *) echo "Invalid option. Please try again." ;;
+    esac
+}
+
+# --- Main Installation and Setup Logic ---
+function run_setup() {
+    # --- Run Base Installation ---
+    echo "--- Starting Base Installation ---"
+    wget -O zi.sh https://raw.githubusercontent.com/kedaivpn/udp-zivpn/main/zi.sh
+    if [ $? -ne 0 ]; then
+        echo "Failed to download the base installer. Aborting."
+        exit 1
+    fi
+    chmod +x zi.sh
+    ./zi.sh
+    if [ $? -ne 0 ]; then
+        echo "Base installation script failed. Aborting."
+        exit 1
+    fi
+    rm zi.sh
+    echo "--- Base Installation Complete ---"
+
+    # --- Setting up Advanced Management ---
+    echo "--- Setting up Advanced Management ---"
+
+    if ! command -v jq &> /dev/null; then
+        echo "Installing jq..."
+        apt-get update && apt-get install -y jq
+    fi
+
+    echo "Clearing initial password(s) set during base installation..."
+    jq '.auth.config = []' /etc/zivpn/config.json > /etc/zivpn/config.json.tmp && mv /etc/zivpn/config.json.tmp /etc/zivpn/config.json
+
+    touch /etc/zivpn/users.db
+
+    RANDOM_PASS="zivpn$(shuf -i 10000-99999 -n 1)"
+    EXPIRY_DATE=$(date -d "+1 day" +%s)
+
+    echo "Creating a temporary initial account..."
+    echo "${RANDOM_PASS}:${EXPIRY_DATE}" >> /etc/zivpn/users.db
+    jq --arg pass "$RANDOM_PASS" '.auth.config += [$pass]' /etc/zivpn/config.json > /etc/zivpn/config.json.tmp && mv /etc/zivpn/config.json.tmp /etc/zivpn/config.json
+
+    echo "Setting up daily expiry check cron job..."
+    cat <<'EOF' > /etc/zivpn/expire_check.sh
+#!/bin/bash
+DB_FILE="/etc/zivpn/users.db"
+CONFIG_FILE="/etc/zivpn/config.json"
+TMP_DB_FILE="${DB_FILE}.tmp"
+CURRENT_DATE=$(date +%s)
+USERS_REMOVED=false
+if [ ! -f "$DB_FILE" ]; then exit 0; fi
+> "$TMP_DB_FILE"
+while IFS=':' read -r password expiry_date; do
+    if [[ -n "$password" ]]; then
+        if [ "$expiry_date" -le "$CURRENT_DATE" ]; then
+            echo "User '${password}' has expired. Removing."
+            jq --arg pass "$password" 'del(.auth.config[] | select(. == $pass))' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp" && mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
+            USERS_REMOVED=true
+        else
+            echo "${password}:${expiry_date}" >> "$TMP_DB_FILE"
+        fi
+    fi
+done < "$DB_FILE"
+mv "$TMP_DB_FILE" "$DB_FILE"
+if [ "$USERS_REMOVED" = true ]; then
+    echo "Restarting zivpn service due to user removal."
+    systemctl restart zivpn.service
+fi
+exit 0
+EOF
+
+    chmod +x /etc/zivpn/expire_check.sh
+    CRON_JOB="0 0 * * * /etc/zivpn/expire_check.sh"
+    (crontab -l 2>/dev/null | grep -Fq "$CRON_JOB") || (crontab -l 2>/dev/null; echo "$CRON_JOB") | crontab -
+
+    restart_zivpn
+
+    # --- System Integration ---
+    echo "--- Integrating management script into the system ---"
+    cp "$0" /usr/local/bin/zivpn-manager
+    chmod +x /usr/local/bin/zivpn-manager
+
+    PROFILE_FILE="/root/.bashrc"
+    if [ -f "/root/.bash_profile" ]; then
+        PROFILE_FILE="/root/.bash_profile"
+    fi
+
+    ALIAS_CMD="alias menu='/usr/local/bin/zivpn-manager'"
+    AUTORUN_CMD="/usr/local/bin/zivpn-manager"
+
+    # Add alias and autorun command if they don't exist
+    grep -qF "$ALIAS_CMD" "$PROFILE_FILE" || echo "$ALIAS_CMD" >> "$PROFILE_FILE"
+    grep -qF "$AUTORUN_CMD" "$PROFILE_FILE" || echo "$AUTORUN_CMD" >> "$PROFILE_FILE"
+
+    echo "The 'menu' command is now available."
+    echo "The management menu will now open automatically on login."
+
+    echo "-----------------------------------------------------"
+    echo "Advanced management setup complete."
+    echo "A temporary account has been created to ensure service starts correctly:"
+    echo "Password: ${RANDOM_PASS}"
+    echo "Expires in: 24 hours"
+    echo "Please use the menu to create your permanent account(s)."
+    echo "-----------------------------------------------------"
+    read -p "Press Enter to continue to the management menu..."
+}
+
+# --- Main Script ---
+if [ ! -f "/etc/systemd/system/zivpn.service" ]; then
+    run_setup
+fi
+
+while true; do
+    show_menu
+    read -p "Press Enter to return to the menu..."
+done

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,27 +1,48 @@
 #!/bin/bash
 # - ZiVPN Remover -
 clear
-echo -e "Uninstalling ZiVPN ..."
+echo -e "Uninstalling ZiVPN and Management Scripts..."
+
+# Stop and disable services
 systemctl stop zivpn.service 1> /dev/null 2> /dev/null
-systemctl stop zivpn_backfill.service 1> /dev/null 2> /dev/null
 systemctl disable zivpn.service 1> /dev/null 2> /dev/null
-systemctl disable zivpn_backfill.service 1> /dev/null 2> /dev/null
+
+# Remove service files
 rm /etc/systemd/system/zivpn.service 1> /dev/null 2> /dev/null
-rm /etc/systemd/system/zivpn_backfill.service 1> /dev/null 2> /dev/null
+
+# Kill any running process
 killall zivpn 1> /dev/null 2> /dev/null
+
+# Remove directories and binaries
 rm -rf /etc/zivpn 1> /dev/null 2> /dev/null
 rm /usr/local/bin/zivpn 1> /dev/null 2> /dev/null
+rm /usr/local/bin/zivpn-manager 1> /dev/null 2> /dev/null
+
+# Remove cron job
+(crontab -l 2>/dev/null | grep -v "/etc/zivpn/expire_check.sh") | crontab -
+
+# Remove system integration from shell profiles
+PROFILE_FILES=("/root/.bashrc" "/root/.bash_profile")
+for PROFILE_FILE in "${PROFILE_FILES[@]}"; do
+    if [ -f "$PROFILE_FILE" ]; then
+        sed -i "/alias menu='\/usr\/local\/bin\/zivpn-manager'/d" "$PROFILE_FILE"
+        sed -i "/\/usr\/local\/bin\/zivpn-manager/d" "$PROFILE_FILE"
+    fi
+done
+
+echo "Verifying removal..."
 if pgrep "zivpn" >/dev/null; then
-  echo -e "Server Running"
+  echo -e "Server process is still running."
 else
-  echo -e "Server Stopped"
+  echo -e "Server process stopped."
 fi
-file="/usr/local/bin/zivpn" 1> /dev/null 2> /dev/null
-if [ -e "$file" ] 1> /dev/null 2> /dev/null; then
-  echo -e "Files still remaining, try again"
+
+if [ -f "/usr/local/bin/zivpn" ] || [ -f "/usr/local/bin/zivpn-manager" ] || [ -d "/etc/zivpn" ]; then
+  echo -e "Files still remaining, please check manually."
 else
-  echo -e "Successfully Removed"
+  echo -e "Successfully Removed All Files."
 fi
+
 echo "Cleaning Cache & Swap"
 echo 3 > /proc/sys/vm/drop_caches
 sysctl -w vm.drop_caches=3


### PR DESCRIPTION
This commit integrates the management script (`install.sh`) into the system for a more seamless user experience.

Key changes:
- During setup, the `install.sh` script now copies itself to `/usr/local/bin/zivpn-manager`.
- Adds entries to the root user's `.bashrc` or `.bash_profile` to:
  1.  Create a `menu` alias, allowing the manager to be launched from any shell session.
  2.  Automatically run the `zivpn-manager` upon root login, immediately presenting the user with the management menu.
- The `uninstall.sh` script has been updated to cleanly remove the `zivpn-manager` binary, the cron job, and the shell profile entries, ensuring a complete uninstall.

This change addresses the user's request to have the menu available automatically on login and accessible via a simple `menu` command, making the tool feel like a native part of the system.